### PR TITLE
Allow meta to be also object instead of only function inside route.

### DIFF
--- a/addon/mixins/route-meta.js
+++ b/addon/mixins/route-meta.js
@@ -46,6 +46,8 @@ export default Ember.Mixin.create({
     return Ember.run.next(this, function() {
       if (typeof this.meta === 'function') {
         return this.setMeta(this.meta());
+      }else if (typeof this.meta === 'object') {
+        return this.setMeta(this.meta);
       }
     });
   },


### PR DESCRIPTION
This gives flexibility to set meta as simply JSON object or also can be set via afterModel hook.