### PR TITLE
Update ember-cli-head version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.6",
-    "ember-cli-head": "0.0.6",
+    "ember-cli-head": "^0.1.1",
     "ember-cli-htmlbars": "^1.0.1"
   },
   "ember-addon": {


### PR DESCRIPTION
Adds support for Ember 2.9+.
