### PR TITLE
Delete .dir-locals.el

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,1 +1,0 @@
-((nil . ((mode . ember))))

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /bower_components
 
 # misc
+.dir-locals.el
 /.sass-cache
 /connect.lock
 /coverage/*


### PR DESCRIPTION
This commit deletes the `.dir-locals.el` configuration file for directory-wide Emacs configurations. The old `.dir-locals.el` configuration would result in a crash every time one visits a file in Emacs unless `ember-mode` is available; it’s better to keep it out of the repository and maintain a personal copy. The previous configuration also had the problem that `ember-mode` would be used everywhere, including overriding Dired when attempting to visit a directory.