### PR TITLE
Update ember-cli-head dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,10 +44,11 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.6",
-    "ember-cli-head": "0.0.6",
+    "ember-cli-head": "^0.1.2",
     "ember-cli-htmlbars": "^1.0.1"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "after": "ember-cli-head"
   }
 }


### PR DESCRIPTION
When a dependency is given and the child dep needs to enforce load order
you need to declare the child loads after the parent. This is done
within the `ember-addon` key in `package.json`