### PR TITLE
Allow `headTags` to be a CP

### DIFF
--- a/addon/services/head-tags.js
+++ b/addon/services/head-tags.js
@@ -1,5 +1,9 @@
 import Ember from 'ember';
 
+const {
+  get
+} = Ember;
+
 //TODO: consider polyfilled Set
 const VALID_HEAD_TAGS = Ember.A([
   'base',
@@ -29,7 +33,7 @@ export default Ember.Service.extend({
   },
 
   _extractHeadTagsFromRoute(route) {
-    let headTags = route.headTags;
+    let headTags = get(route, 'headTags');
     if (!headTags) {
       return {};
     }

--- a/tests/unit/services/head-tags-test.js
+++ b/tests/unit/services/head-tags-test.js
@@ -1,4 +1,9 @@
+import Ember from 'ember';
 import { moduleFor, test } from 'ember-qunit';
+
+const {
+  computed
+} = Ember;
 
 moduleFor('service:head-tags', 'Unit | Service | head tags', {
   // Specify the other units that are required for this test.
@@ -17,6 +22,38 @@ test('it collects head tags from function', function(assert) {
         }
       }];
     }
+  };
+  var service = this.subject({
+    router: {
+      router: {
+        currentHandlerInfos: [{ handler }]
+      }
+    }
+  });
+
+  service.collectHeadTags();
+  assert.deepEqual(
+    service.get('headData.headTags'),
+    [{
+      type: 'link',
+      attrs: {
+        rel: 'canonical'
+      }
+    }]
+  );
+});
+
+test('it collects head tags from CP', function(assert) {
+  assert.expect(1);
+  let handler = {
+    headTags: computed(function() {
+      return [{
+        type: 'link',
+        attrs: {
+          rel: 'canonical'
+        }
+      }];
+    })
   };
   var service = this.subject({
     router: {


### PR DESCRIPTION
This will allow the `headTags` array to be recomputed more easily