### PR TITLE
Support FastBoot 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "ember-cli-babel": "^6.0.0",
-    "ember-cli-head": "^0.2.0",
+    "ember-cli-head": "^0.2.1",
     "ember-cli-htmlbars": "^1.1.1",
     "ember-runtime-enumerable-includes-polyfill": "^2.0.0"
   },


### PR DESCRIPTION
Bump ember-cli-head to 0.2.1, supporting FastBoot 1.0 (see https://github.com/ronco/ember-cli-head/pull/21)