### PR TITLE
Access currentHandlersInfos properly on ember-cli 2.15, avoid router.router deprecation warning

### DIFF
--- a/addon/services/head-tags.js
+++ b/addon/services/head-tags.js
@@ -24,10 +24,14 @@ export default Ember.Service.extend({
   // crawl up the active route stack and collect head tags
   collectHeadTags() {
     let tags = {};
-    let currentHandlerInfos = this.get('router._routerMicrolib.currentHandlerInfos');
-    if (!currentHandlerInfos) {
+    let currentHandlerInfos = null;
+
+    if (this.get('router._routerMicrolib')) {
+      currentHandlerInfos = this.get('router._routerMicrolib.currentHandlerInfos');
+    } else {
       currentHandlerInfos = this.get('router.router.currentHandlerInfos');
     }
+
     let handlerInfos = Ember.A(currentHandlerInfos);
     handlerInfos.forEach((handlerInfo) => {
       assign(tags, this._extractHeadTagsFromRoute(handlerInfo.handler));


### PR DESCRIPTION
Right now, if you are on ember-cli 2.15 or greater (the one where the public routing service is available) you will see deprecation warnings in your console from ember-cli-meta-tags. 
The issue is in code accessing the `currentHandlersInfos` from the router in the `head-tags` service `collectHeadTags` method.  

In the current source, the logic looks like:

```javascript
let currentHandlerInfos = this.get('router._routerMicrolib.currentHandlerInfos');
if (!currentHandlerInfos) {
  currentHandlerInfos = this.get('router.router.currentHandlerInfos');
}
```

The logic above is incorrect as you will always fall into the older `router.router` pathway if you have not defined any `currentHandlerInfos`. Causing [this](https://emberjs.com/deprecations/v2.x/#toc_ember-router-router-renamed-to-ember-router-_routermicrolib) deprecation warning. 

This PR changes the above code to:

```javascript
let currentHandlerInfos = null;

if (this.get('router._routerMicrolib')) {
  currentHandlerInfos = this.get('router._routerMicrolib.currentHandlerInfos');
} else {
  currentHandlerInfos = this.get('router.router.currentHandlerInfos');
}
```

This properly checks to see if you have the latest and greatest public routing service before falling back to the deprecated api. 


