### PR TITLE
TypeScript ambient type information

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,26 @@
+export interface HeadTag<K = string, T = any> {
+  type: K;
+  tagId: string;
+  attrs: T;
+}
+
+declare module 'ember-cli-meta-tags/services/head-tags' {
+  import Service from '@ember/service';
+  class HeadTagsService extends Service {
+    collectHeadTags(): void;
+  }
+}
+
+declare module 'ember-cli-head/services/head-data' {
+  interface HeadDataService {
+    headTags?: HeadTag[];
+  }
+}
+
+declare module 'ember' {
+  namespace Ember {
+    interface Route {
+      headTags?: HeadTag[] | (() => HeadTag[]);
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "ember-runtime-enumerable-includes-polyfill": "^2.0.0"
   },
   "devDependencies": {
+    "@types/ember": "^2.8.4",
     "broccoli-asset-rev": "^2.4.5",
     "ember-ajax": "^3.0.0",
     "ember-cli": "2.13.0",


### PR DESCRIPTION
Because this is an 'extension of ember' kind of addon (often used without being explicitly imported), consumers will need to do **one of two things** in order to take advantage of this type information.

### A. Indicate that this type information is to be included
##### tsconfig.json
```json
{
  "compilerOptions": {
      "types": [
         "ember-cli-meta-tags"
       ]
  }
}
``` 

### B. Import the entry point for this addon from somewhere in their project

##### app/app.ts
```ts
import Application from '@ember/application';
import loadInitializers from 'ember-load-initializers';
import config from './config/environment';
import Resolver from './resolver';
// ⬇️ ⬇️ ⬇️ ⬇️ ⬇️ ⬇️ ⬇️ ⬇️ ⬇️ ⬇️ ⬇️ ⬇️ 
import 'ember-cli-meta-tags';

const App = Application.extend({ ... });
```

After doing either (A) or (B), type-checking will
* Accurately represent that there's a `head-tags` service with a `collectHeadTags()` function on it
* Accurately represent that the `head-data` service has a `headTags` property on it
* Accurately represent that Routes can now have a `headTags` property, containing either the array of tags or a function that returns the array

A "tag" is represented as an object having a `type` and `tagId` property, an an `attrs` property defined by an optional generic (by default, an `any`). This allows developers to define their own specific constraints on top of this

```ts
import { HeadTag } from 'ember-cli-meta-tags';

type TwitterCardTag = HeadTag<'meta', {name: string, content: string}>;

// <meta name='twitter:card' content='video' />
let twCardTypeTag: TwitterCardTag = {
  type: 'meta',
  tagId: 'card-type',
  attrs: {
    name: 'twitter:card',
    content: 'video'
  }
}
```