### PR TITLE
update head to 0.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ create a custom `app/templates/head.hbs` file and include
 
 ### Adding Tags Automatically On Transition
 
-In older to dynamically add head tags from your routes all you need to
+In order to dynamically add head tags from your routes all you need to
 do is provide a `headTags` property on the route.  This property can
 either be an array of tags, or a function which when invoked with the
 route's context returns an array of tags.  The head tags service will

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ correctly.
 This add-on is perfect for combining with a prerendering
 server side solution such as [prerender.io](http://www.prerender.io)
 or with
-[Ember Fastboot](https://github.com/tildeio/ember-cli-fastboot) (Fastboot compatibility requires ember-cli-meta-tags v2+ and Ember 2.7+ (currently beta)).
+[Ember FastBoot](https://github.com/tildeio/ember-cli-fastboot) (FastBoot compatibility requires ember-cli-meta-tags v2+ and Ember 2.7+ (currently beta)).
 
 ## Usage
 
@@ -28,15 +28,15 @@ ember install ember-cli-meta-tags
 
 Version 5.0 of this addon depends on [ember-cli-head](https://github.com/ronco/ember-cli-head) 0.4.0, which adds the requirement that the `{{head-layout}}` is added once in an application-wide template (usually `app/templates/application.hbs`). For more info, see the [ember-cli-head 0.4 upgrade note](https://github.com/ronco/ember-cli-head#upgrade-to-04x).
 
-### Using with Ember Fastboot
+### Using with Ember FastBoot
 
-Version 4.0+ of this addon is designed to work with Fastboot >= 1.0.0-rc1. If you use
+Version 4.0+ of this addon is designed to work with FastBoot >= 1.0.0-rc1. If you use
 an order version of fastboot stick with 3.X.
 
 Version 2.0+ of this addon is built upon
 [ember-cli-head](https://github.com/ronco/ember-cli-head) and as a
-result is will work automatically out of the box with Ember Fastboot
-if you are running a version of ember >= 2.7.
+result it will work automatically out of the box with Ember FastBoot
+if you are running a version of Ember >= 2.7.
 
 #### Using with other ember-cli-head addons
 
@@ -53,7 +53,7 @@ create a custom `app/templates/head.hbs` file and include
 
 ### Adding Tags Automatically On Transition
 
-In order to dynamically add head tags from your routes all you need to
+In older to dynamically add head tags from your routes all you need to
 do is provide a `headTags` property on the route.  This property can
 either be an array of tags, or a function which when invoked with the
 route's context returns an array of tags.  The head tags service will

--- a/README.md
+++ b/README.md
@@ -125,11 +125,11 @@ export default Route.extend({
 import Route from '@ember/routing/route';
 
 export default Route.extend({
-  afterModel: function(model) {
+  afterModel(model) {
     this.setHeadTags(model);
   },
 
-  setHeadTags: function(model) {
+  setHeadTags(model) {
     let headTags = [{
       type: 'meta',
       tagId: 'meta-description-tag',
@@ -156,7 +156,7 @@ that returns the appropriate head tags.
 import Route from '@ember/routing/route';
 
 export default Route.extend({
-  headTags: function() {
+  headTags() {
     // here we are pulling meta data from the model for this route
     let model = this.modelFor(this.routeName);
     return [{
@@ -199,7 +199,7 @@ all of the headTags in the current route hierarchy will be re-built.
 import Route from '@ember/routing/route';
 
 export default Route.extend(RouteMetaMixin, {
-  headTags: function() {
+  headTags() {
     let controller = this.controllerFor(this.routeName);
     // value of head tags updates with value of `era` on this
     // route's controller

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ ember install ember-cli-meta-tags
 ### Upgrading to 5.x
 
 Version 5.0 of this addon depends on [ember-cli-head](https://github.com/ronco/ember-cli-head) 0.4.0, which adds the requirement that the `{{head-layout}}` is added once in an application-wide template (usually `app/templates/application.hbs`). For more info, see the [ember-cli-head 0.4 upgrade note](https://github.com/ronco/ember-cli-head#upgrade-to-04x).
-And add `{{head-layout}}` to the top of your application template.  Required for version `5.0.0` or greater.
 
 ### Using with Ember Fastboot
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,10 @@ In your Ember CLI project directory run:
 ember install ember-cli-meta-tags
 ```
 
-And add `{{head-layout}}` to the top of your application template.  Required for version `0.5.0` or greater.
+### Upgrading to 5.x
+
+Version 5.0 of this addon depends on [ember-cli-head](https://github.com/ronco/ember-cli-head) 0.4.0, which adds the requirement that the `{{head-layout}}` is added once in an application-wide template (usually `app/templates/application.hbs`). For more info, see the [ember-cli-head 0.4 upgrade note](https://github.com/ronco/ember-cli-head#upgrade-to-04x).
+And add `{{head-layout}}` to the top of your application template.  Required for version `5.0.0` or greater.
 
 ### Using with Ember Fastboot
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ In your Ember CLI project directory run:
 ember install ember-cli-meta-tags
 ```
 
+And add `{{head-layout}}` to the top of your application template.  Required for version `0.5.0` or greater.
+
 ### Using with Ember Fastboot
 
 Version 4.0+ of this addon is designed to work with Fastboot >= 1.0.0-rc1. If you use
@@ -94,9 +96,9 @@ the didTransition event.
 ###### Example: static headTags property on the route
 ```javascript
 // app/routes/some-page.js
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend({
+export default Route.extend({
   headTags: [{
       type: 'meta',
       tagId: 'meta-og-name',
@@ -118,7 +120,9 @@ export default Ember.Route.extend({
 
 ###### Example: Setting the headTags property in afterModel
 ```javascript
-export default Ember.Route.extend({
+import Route from '@ember/routing/route';
+
+export default Route.extend({
   afterModel: function(model) {
     this.setHeadTags(model);
   },
@@ -147,9 +151,9 @@ that returns the appropriate head tags.
 
 ```javascript
 // app/routes/some-page.js
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend({
+export default Route.extend({
   headTags: function() {
     // here we are pulling meta data from the model for this route
     let model = this.modelFor(this.routeName);
@@ -190,9 +194,9 @@ all of the headTags in the current route hierarchy will be re-built.
 
 ```javascript
 // app/routes/some-page.js
-import Ember from 'ember';
+import Route from '@ember/routing/route';
 
-export default Ember.Route.extend(RouteMetaMixin, {
+export default Route.extend(RouteMetaMixin, {
   headTags: function() {
     let controller = this.controllerFor(this.routeName);
     // value of head tags updates with value of `era` on this
@@ -210,9 +214,9 @@ export default Ember.Route.extend(RouteMetaMixin, {
 
 
 // app/controller/some-page.js
-import Ember from 'ember';
+import Controller from '@ember/controller';
 
-export default Ember.Controller.extend({
+export default Controller.extend({
   headTagsService: Ember.inject.service('head-tags'),
   queryParameters: {
     era: 'e'
@@ -240,17 +244,16 @@ Instructions for developing on this add-on.
 
 * `git clone` this repository
 * `npm install`
-* `bower install`
 
 ### Running
 
-* `ember server`
+* `ember serve`
 * Visit your app at http://localhost:4200.
 
 ### Running Tests
 
 * `ember test`
-* `ember test --server`
+* `ember test --serve`
 
 ### Building
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "ember-cli-babel": "^6.6.0",
-    "ember-cli-head": "^0.3.0",
+    "ember-cli-head": "^0.4.1",
     "ember-cli-htmlbars": "^2.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,10 @@
     "node": "^4.5 || 6.* || >= 7.*"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "after": "ember-cli-head",
+    "versionCompatibility": {
+      "ember": ">2.10.0"
+    }
   }
 }

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,3 +1,5 @@
+{{head-layout}}
+
 <h2 id="title">Welcome to Ember.js</h2>
 
 <ul>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1856,7 +1856,7 @@ electron-to-chromium@^1.3.47:
   version "1.3.48"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.48.tgz#d3b0d8593814044e092ece2108fc3ac9aea4b900"
 
-ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.1.0, ember-cli-babel@^6.11.0, ember-cli-babel@^6.12.0, ember-cli-babel@^6.3.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2:
+ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.11.0, ember-cli-babel@^6.12.0, ember-cli-babel@^6.3.0, ember-cli-babel@^6.6.0, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2:
   version "6.14.1"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.14.1.tgz#796339229035910b625593caffbc2683792ada68"
   dependencies:
@@ -1907,12 +1907,12 @@ ember-cli-get-component-path-option@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ember-cli-get-component-path-option/-/ember-cli-get-component-path-option-1.0.0.tgz#0d7b595559e2f9050abed804f1d8eff1b08bc771"
 
-ember-cli-head@^0.3.0:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/ember-cli-head/-/ember-cli-head-0.3.1.tgz#a407df4880f235280371c437bb5b0b5cbdaea646"
+ember-cli-head@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/ember-cli-head/-/ember-cli-head-0.4.1.tgz#28b7ee86439746640834b232a3b34ab1329f3cf3"
   dependencies:
-    ember-cli-babel "^6.1.0"
-    ember-cli-htmlbars "^2.0.1"
+    ember-cli-babel "^6.11.0"
+    ember-cli-htmlbars "^2.0.3"
 
 ember-cli-htmlbars-inline-precompile@^1.0.0:
   version "1.0.3"
@@ -1924,7 +1924,7 @@ ember-cli-htmlbars-inline-precompile@^1.0.0:
     heimdalljs-logger "^0.1.9"
     silent-error "^1.1.0"
 
-ember-cli-htmlbars@^2.0.1:
+ember-cli-htmlbars@^2.0.1, ember-cli-htmlbars@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-2.0.3.tgz#e116e1500dba12f29c94b05b9ec90f52cb8bb042"
   dependencies:


### PR DESCRIPTION
@begedin I think we could version bump to `4.1` before merging this.  Then after this PR, perhaps release `5.0`.  Users need to add `{{head-layout}}` to their application.hbs file now (see PR below).

https://github.com/ronco/ember-cli-head/pull/37

close #57 #60 #63 #67 