### PR TITLE
Skip tags collection when route does not resolve successfully

### DIFF
--- a/addon/services/head-tags.js
+++ b/addon/services/head-tags.js
@@ -35,7 +35,9 @@ export default Service.extend({
     let handlerInfos = A(currentHandlerInfos);
     handlerInfos.forEach((handlerInfo) => {
       if (gte('3.6.0-beta.1')) {
-        assign(tags, this._extractHeadTagsFromRoute(handlerInfo.route));
+        if (handlerInfo.isResolved){
+          assign(tags, this._extractHeadTagsFromRoute(handlerInfo.route));
+        }
       } else {
         assign(tags, this._extractHeadTagsFromRoute(handlerInfo.handler));
       }

--- a/tests/acceptance/route-meta-test-test.js
+++ b/tests/acceptance/route-meta-test-test.js
@@ -111,3 +111,15 @@ module('Acceptance: RouteMetaMixin', function(hooks) {
     );
   });
 });
+
+module('Acceptance: RouteMetaMixin with failure', function(hooks) {
+  setupApplicationTest(hooks);
+
+  test('Does not have meta if model hook fails', async function(assert) {
+    await visit('/route-with-error');
+    assert.equal(
+      await document.querySelectorAll('meta[property="og:name"]').length,
+      0
+    );
+  });
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -16,6 +16,7 @@ Router.map(function() {
       this.route('deep');
     });
   });
+  this.route('route-with-error');
 });
 
 export default Router;

--- a/tests/dummy/app/routes/route-with-error.js
+++ b/tests/dummy/app/routes/route-with-error.js
@@ -1,0 +1,24 @@
+import Route from '@ember/routing/route';
+import RouteMetaMixin from 'ember-cli-meta-tags/mixins/route-meta';
+import { reject } from 'rsvp';
+
+export default Route.extend(RouteMetaMixin, {
+  name: 'Ice-T',
+  meta() {
+    return {
+      'property': {
+        'og:name': this.get('name')
+      }
+    };
+  },
+
+  model(){
+    return reject(new Error('Fake error to simulate failure in model hooks'));
+  },
+
+  actions: {
+    error(){
+      // handles error thrown from the model() hook
+    },
+  }
+});

--- a/tests/unit/services/head-tags-test.js
+++ b/tests/unit/services/head-tags-test.js
@@ -27,7 +27,7 @@ module('Unit | Service | head tags', function(hooks) {
         },
         targetState: {
           routerJsState: {
-            routeInfos: [{ route }]
+            routeInfos: [{ route, isResolved: true }]
           }
         }
       }
@@ -66,7 +66,7 @@ module('Unit | Service | head tags', function(hooks) {
         },
         targetState: {
           routerJsState: {
-            routeInfos: [{ route }]
+            routeInfos: [{ route, isResolved: true }]
           }
         }
       }
@@ -103,7 +103,7 @@ module('Unit | Service | head tags', function(hooks) {
         },
         targetState: {
           routerJsState: {
-            routeInfos: [{ route }]
+            routeInfos: [{ route, isResolved: true }]
           }
         }
       }
@@ -127,6 +127,7 @@ module('Unit | Service | head tags', function(hooks) {
     assert.expect(1);
     let routes = [
       {
+        isResolved: true,
         handler: {
           headTags: [
             {
@@ -168,6 +169,7 @@ module('Unit | Service | head tags', function(hooks) {
           ]
         }
       },{
+        isResolved: true,
         handler: {
           headTags() {
             return [
@@ -259,5 +261,37 @@ module('Unit | Service | head tags', function(hooks) {
         }
       ]
     );
+  });
+
+  test('it does not collect head tags if route is not resolved', function(assert) {
+    assert.expect(1);
+    let route = {
+      headTags() {
+        return [{
+          type: 'link',
+          attrs: {
+            rel: 'canonical'
+          }
+        }];
+      }
+    };
+    let service = this.owner.factoryFor('service:head-tags').create({
+      router: {
+        _routerMicrolib: {
+          currentHandlerInfos: [{ handler: route, route }]
+        },
+        targetState: {
+          routerJsState: {
+            routeInfos: [{ route, isResolved: false }]
+          }
+        }
+      }
+    });
+
+    run(() => {
+      service.collectHeadTags();
+    });
+
+    assert.deepEqual(service.get('headData.headTags'), []);
   });
 });


### PR DESCRIPTION
Currently, within new Ember, the addon is trying to collect tags no matter whether the transition is successful or not:
https://github.com/ronco/ember-cli-meta-tags/blob/master/addon/initializers/router-head-tags.js#L15
https://github.com/ronco/ember-cli-meta-tags/blob/master/addon/services/head-tags.js#L38

This causes a problem because the DOCs assume that the `headTags()` function will be called once the model resolves:
```
// app/routes/some-page.js
import Route from '@ember/routing/route';

export default Route.extend({
  headTags() {
    // here we are pulling meta data from the model for this route
    let model = this.modelFor(this.routeName);
    return [{
      type: 'meta',
      tagId: 'meta-description-tag',
      attrs: {
        name: 'description',
        content: model.get('description')
      }
    }];
  }
});
```

Looking at the EmberJS DOCs it seems that semantics behind `didTransition` [route action](https://emberjs.com/api/ember/3.7/classes/Route/events/didTransition?anchor=didTransition&show=private) and `routeDidChange` [event](https://emberjs.com/api/ember/3.7/classes/RouterService/events/routeDidChange?anchor=routeDidChange) are slightly different:
> The didTransition action is fired after a transition has successfully been completed. This occurs after the normal model hooks (beforeModel, model, afterModel, setupController) have resolved. 

> The routeDidChange event only fires once a transition has settled. This includes aborts and error substates. Like the routeWillChange event it receives a Transition as the sole argument.

`routeDidChange` fires also on error substates, hence the asynchronous hooks are not necessarily bringing a valid values to work with in the `headTags()` function. 

Instead of handling this on app level (checking for model in every headTags() function), we propose a PR that should fix the issue.