### PR TITLE
[Bug]: use `this` context for model in head template

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ create a custom `app/templates/head.hbs` file and include
 `ember-cli-meta-tag`'s component:
 
 ```hbs
-<HeadTags @headTags={{@model.headTags}} />
+<HeadTags @headTags={{this.model.headTags}} />
 ```
 
 ### Adding Tags Automatically On Transition

--- a/app/templates/head.hbs
+++ b/app/templates/head.hbs
@@ -1,1 +1,1 @@
-<HeadTags @headTags={{@model.headTags}} />
+<HeadTags @headTags={{this.model.headTags}} />


### PR DESCRIPTION
https://github.com/ronco/ember-cli-meta-tags/pull/81/files

close #90 