### PR TITLE
tests/head-tag: Fix `id` conflict

### DIFF
--- a/tests/integration/components/head-tag-test.js
+++ b/tests/integration/components/head-tag-test.js
@@ -69,8 +69,8 @@ module('Integration | Component | head tag', function(hooks) {
         attrs
       }
     );
-    await render(hbs`{{head-tag headTag=headTag id='test-comp'}}`);
-    let elem = this.element.querySelector('#test-comp');
+    await render(hbs`{{head-tag headTag=headTag}}`);
+    let elem = this.element.querySelector('meta');
     Object.keys(attrs).forEach(function(key) {
       assert.equal(elem.getAttribute(key), attrs[key]);
     });


### PR DESCRIPTION
The `id='test-comp'` has priority over the the `attrs.id` that we also pass in. This leads to the `assert.equal()` failing for the `id`, because it is `test-comp`, not `the-id`. With this change we remove the `id='test-comp'` and just run the assertions on the `<meta>` tag without an element ID selector. This should work fine, as long as we use `this.element.querySelector()` instead of `document.querySelector()`.

This should fix the test suite when run locally. CI is still failing for various other reasons that I will address in a follow-up PR.

/cc @snewcomer @cibernox 